### PR TITLE
[Backport] Fix issue #14895 - Change Password warning message appear two times

### DIFF
--- a/app/code/Magento/User/Model/User.php
+++ b/app/code/Magento/User/Model/User.php
@@ -47,6 +47,8 @@ class User extends AbstractModel implements StorageInterface, UserInterface
     /** @deprecated */
     const XML_PATH_RESET_PASSWORD_TEMPLATE = 'admin/emails/reset_password_template';
 
+    const MESSAGE_ID_PASSWORD_EXPIRED = 'magento_user_password_expired';
+
     /**
      * Model event prefix
      *

--- a/app/code/Magento/User/Observer/Backend/AuthObserver.php
+++ b/app/code/Magento/User/Observer/Backend/AuthObserver.php
@@ -149,7 +149,7 @@ class AuthObserver implements ObserverInterface
     /**
      * Update locking information for the user
      *
-     * @param \Magento\User\Model\User $user
+     * @param User $user
      * @return void
      */
     private function _updateLockingInformation($user)
@@ -195,10 +195,14 @@ class AuthObserver implements ObserverInterface
                 $myAccountUrl = $this->url->getUrl('adminhtml/system_account/');
                 $message = __('It\'s time to <a href="%1">change your password</a>.', $myAccountUrl);
             }
+
+            // Avoid duplicating the message
+            $this->messageManager->getMessages()->deleteMessageByIdentifier(User::MESSAGE_ID_PASSWORD_EXPIRED);
+
             $this->messageManager->addNoticeMessage($message);
             $message = $this->messageManager->getMessages()->getLastAddedMessage();
             if ($message) {
-                $message->setIdentifier('magento_user_password_expired')->setIsSticky(true);
+                $message->setIdentifier(User::MESSAGE_ID_PASSWORD_EXPIRED)->setIsSticky(true);
                 $this->authSession->setPciAdminUserIsPasswordExpired(true);
             }
         }

--- a/app/code/Magento/User/Observer/Backend/AuthObserver.php
+++ b/app/code/Magento/User/Observer/Backend/AuthObserver.php
@@ -196,11 +196,13 @@ class AuthObserver implements ObserverInterface
                 $message = __('It\'s time to <a href="%1">change your password</a>.', $myAccountUrl);
             }
 
-            // Avoid duplicating the message
-            $this->messageManager->getMessages()->deleteMessageByIdentifier(User::MESSAGE_ID_PASSWORD_EXPIRED);
+            $messages = $this->messageManager->getMessages();
+
+            // Remove existing messages with same ID to avoid duplication
+            $messages->deleteMessageByIdentifier(User::MESSAGE_ID_PASSWORD_EXPIRED);
 
             $this->messageManager->addNoticeMessage($message);
-            $message = $this->messageManager->getMessages()->getLastAddedMessage();
+            $message = $messages->getLastAddedMessage();
             if ($message) {
                 $message->setIdentifier(User::MESSAGE_ID_PASSWORD_EXPIRED)->setIsSticky(true);
                 $this->authSession->setPciAdminUserIsPasswordExpired(true);

--- a/app/code/Magento/User/Observer/Backend/TrackAdminNewPasswordObserver.php
+++ b/app/code/Magento/User/Observer/Backend/TrackAdminNewPasswordObserver.php
@@ -8,6 +8,7 @@ namespace Magento\User\Observer\Backend;
 
 use Magento\Framework\Event\Observer as EventObserver;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\User\Model\User;
 
 /**
  * User backend observer model for passwords
@@ -74,7 +75,7 @@ class TrackAdminNewPasswordObserver implements ObserverInterface
             $passwordHash = $user->getPassword();
             if ($passwordHash && !$user->getForceNewPassword()) {
                 $this->userResource->trackPassword($user, $passwordHash);
-                $this->messageManager->getMessages()->deleteMessageByIdentifier('magento_user_password_expired');
+                $this->messageManager->getMessages()->deleteMessageByIdentifier(User::MESSAGE_ID_PASSWORD_EXPIRED);
                 $this->authSession->unsPciAdminUserIsPasswordExpired();
             }
         }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14897
The password change notice was a sticky message activated by admin_user_authenticate_after event.
The password change page requires the current user password and thus triggering admin_user_authenticate_after while saving.
One message was added every time the user was saved.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#14895: Change Password warning message appear two times

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
