### PR TITLE
[Backport] #14063 - Wrong invoice prefix in multistore setup due to default stor…

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/EntityAbstract.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/EntityAbstract.php
@@ -121,10 +121,15 @@ abstract class EntityAbstract extends AbstractDb
     {
         /** @var \Magento\Sales\Model\AbstractModel $object */
         if ($object instanceof EntityInterface && $object->getIncrementId() == null) {
+            $store = $object->getStore();
+            $storeId = $store->getId();
+            if ($storeId === null) {
+                $storeId = $store->getGroup()->getDefaultStoreId();
+            }
             $object->setIncrementId(
                 $this->sequenceManager->getSequence(
                     $object->getEntityType(),
-                    $object->getStore()->getGroup()->getDefaultStoreId()
+                    $storeId
                 )->getNextValue()
             );
         }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15332
…e id

<!--- Provide a general summary of the Pull Request in the Title above -->
Set correct store id for Invoice
### Description
I have taken correct store id from store object.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<14063>: Wrong invoice prefix in multistore setup due to default store id
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create Multiple Store View
2. Place an order from different store view and create an invoice
3. Check Invoice prefix for different store view

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
